### PR TITLE
Adds clear_override flag to all PACMod 3 command messages.

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,3 +1,4 @@
 - git:
     local-name: astuff_sensor_msgs
     uri: https://github.com/astuff/astuff_sensor_msgs
+    version: maint/add_clear_override_flag

--- a/pacmod3/include/pacmod3/pacmod3_core.h
+++ b/pacmod3/include/pacmod3/pacmod3_core.h
@@ -516,6 +516,7 @@ namespace PACMod3
     public:
       void encode(bool enable,
                   bool ignore_overrides,
+                  bool clear_override,
                   bool cmd);
   };
 
@@ -525,6 +526,7 @@ namespace PACMod3
     public:
       void encode(bool enable,
                   bool ignore_overrides,
+                  bool clear_override,
                   float cmd);
   };
 
@@ -534,6 +536,7 @@ namespace PACMod3
     public:
       void encode(bool enable,
                   bool ignore_overrides,
+                  bool clear_override,
                   uint8_t cmd);
   };
 
@@ -615,6 +618,7 @@ namespace PACMod3
 
       void encode(bool enabled,
                   bool ignore_overrides,
+                  bool clear_override,
                   float steer_pos,
                   float steer_spd);
   };

--- a/pacmod3/src/pacmod3_core.cpp
+++ b/pacmod3/src/pacmod3_core.cpp
@@ -569,23 +569,27 @@ Pacmod3RxMsg::Pacmod3RxMsg() :
 
 void SystemCmdBool::encode(bool enable,
                            bool ignore_overrides,
+                           bool clear_override,
                            bool cmd)
 {
   data.assign(8, 0);
 
   data[0] = (enable ? 0x01 : 0x00);
   data[0] |= (ignore_overrides ? 0x02 : 0x00);
+  data[0] |= clear_override ? 0x04 : 0x00;
   data[1] = (cmd ? 0x00 : 0x01);
 }
 
 void SystemCmdFloat::encode(bool enable,
                             bool ignore_overrides,
+                            bool clear_override,
                             float cmd)
 {
   data.assign(8, 0);
 
   data[0] = enable ? 0x01 : 0x00;
   data[0] |= ignore_overrides ? 0x02 : 0x00;
+  data[0] |= clear_override ? 0x04 : 0x00;
 
   uint16_t cmd_float = (uint16_t)(cmd * 1000.0);
   data[1] = (cmd_float & 0xFF00) >> 8;
@@ -594,17 +598,20 @@ void SystemCmdFloat::encode(bool enable,
 
 void SystemCmdInt::encode(bool enable,
                           bool ignore_overrides,
+                          bool clear_override,
                           uint8_t cmd)
 {
   data.assign(8, 0);
 
   data[0] = enable ? 0x01 : 0x00;
   data[0] |= ignore_overrides ? 0x02 : 0x00;
+  data[0] |= clear_override ? 0x04 : 0x00;
   data[1] = cmd;
 }
 
 void SteerCmdMsg::encode(bool enable,
                          bool ignore_overrides,
+                         bool clear_override,
                          float steer_pos,
                          float steer_spd)
 {
@@ -612,6 +619,7 @@ void SteerCmdMsg::encode(bool enable,
 
   data[0] = enable ? 0x01 : 0x00;
   data[0] |= ignore_overrides ? 0x02 : 0x00;
+  data[0] |= clear_override ? 0x04 : 0x00;
 
   int16_t raw_pos = (int16_t)(1000.0 * steer_pos);
   uint16_t raw_spd = (uint16_t)(1000.0 * steer_spd);

--- a/pacmod3/src/pacmod3_node.cpp
+++ b/pacmod3/src/pacmod3_node.cpp
@@ -440,6 +440,7 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
       {
         bool cmd_says_enabled = ((rx_it->second->getData()[0] & 0x01) > 0);
         bool cmd_says_ignore_overrides = ((rx_it->second->getData()[0] & 0x02) > 0);
+        bool cmd_says_clear_override = ((rx_it->second->getData()[0] & 0x04) > 0);
 
         if (msg->id == AccelRptMsg::CAN_ID && !accel_encoder.recent_state_change)
         {
@@ -460,7 +461,7 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
               // If we currently think we're enabled but
               // the PACMod says otherwise, accept what the
               // PACMod says and write the output value too.
-              accel_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, dc_parser->output);
+              accel_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
               rx_it->second->setData(accel_encoder.data);
             }
           }
@@ -469,7 +470,7 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
             // If we agree with the PACMod on the state
             // and we both think we're disabled,
             // write the output value and save the disabled state.
-            accel_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, dc_parser->output);
+            accel_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
             rx_it->second->setData(accel_encoder.data);
           }
         }
@@ -486,13 +487,13 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
             
             if (cmd_says_enabled)
             {
-              brake_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, dc_parser->output);
+              brake_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
               rx_it->second->setData(brake_encoder.data);
             }
           }
           else if (!cmd_says_enabled)
           {
-            brake_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, dc_parser->output);
+            brake_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
             rx_it->second->setData(brake_encoder.data);
           }
         }
@@ -507,13 +508,13 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
 
             if (cmd_says_enabled)
             {
-              cruise_control_buttons_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, dc_parser->output);
+              cruise_control_buttons_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
               rx_it->second->setData(cruise_control_buttons_encoder.data);
             }
           }
           else if (!cmd_says_enabled)
           {
-            cruise_control_buttons_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, dc_parser->output);
+            cruise_control_buttons_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
             rx_it->second->setData(cruise_control_buttons_encoder.data);
           }
         }
@@ -528,13 +529,13 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
 
             if (cmd_says_enabled)
             {
-              dash_controls_left_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, dc_parser->output);
+              dash_controls_left_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
               rx_it->second->setData(dash_controls_left_encoder.data);
             }
           }
           else if (!cmd_says_enabled)
           {
-            dash_controls_left_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, dc_parser->output);
+            dash_controls_left_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
             rx_it->second->setData(dash_controls_left_encoder.data);
           }
         }
@@ -549,13 +550,13 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
 
             if (cmd_says_enabled)
             {
-              dash_controls_right_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, dc_parser->output);
+              dash_controls_right_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
               rx_it->second->setData(dash_controls_right_encoder.data);
             }
           }
           else if (!cmd_says_enabled)
           {
-            dash_controls_right_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, dc_parser->output);
+            dash_controls_right_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
             rx_it->second->setData(dash_controls_right_encoder.data);
           }
         }
@@ -570,13 +571,13 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
 
             if (cmd_says_enabled)
             {
-              headlight_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, dc_parser->output);
+              headlight_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
               rx_it->second->setData(headlight_encoder.data);
             }
           }
           else if (!cmd_says_enabled)
           {
-            headlight_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, dc_parser->output);
+            headlight_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
             rx_it->second->setData(headlight_encoder.data);
           }
         }
@@ -591,13 +592,13 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
 
             if (cmd_says_enabled)
             {
-              horn_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, dc_parser->output);
+              horn_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
               rx_it->second->setData(horn_encoder.data);
             }
           }
           else if (!cmd_says_enabled)
           {
-            horn_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, dc_parser->output);
+            horn_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
             rx_it->second->setData(horn_encoder.data);
           }
         }
@@ -612,13 +613,13 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
 
             if (cmd_says_enabled)
             {
-              media_controls_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, dc_parser->output);
+              media_controls_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
               rx_it->second->setData(media_controls_encoder.data);
             }
           }
           else if (!cmd_says_enabled)
           {
-            media_controls_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, dc_parser->output);
+            media_controls_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
             rx_it->second->setData(media_controls_encoder.data);
           }
         }
@@ -633,13 +634,13 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
 
             if (cmd_says_enabled)
             {
-              parking_brake_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, dc_parser->output);
+              parking_brake_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
               rx_it->second->setData(parking_brake_encoder.data);
             }
           }
           else if (!cmd_says_enabled)
           {
-            parking_brake_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, dc_parser->output);
+            parking_brake_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
             rx_it->second->setData(parking_brake_encoder.data);
           }
         }
@@ -654,13 +655,13 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
 
             if (cmd_says_enabled)
             {
-              shift_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, dc_parser->output);
+              shift_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
               rx_it->second->setData(shift_encoder.data);
             }
           }
           else if (!cmd_says_enabled)
           {
-            shift_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, dc_parser->output);
+            shift_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
             rx_it->second->setData(shift_encoder.data);
           }
         }
@@ -677,13 +678,13 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
 
             if (cmd_says_enabled)
             {
-              steer_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, dc_parser->output, cmd_turn_rate);
+              steer_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output, cmd_turn_rate);
               rx_it->second->setData(steer_encoder.data);
             }
           }
           else if (!cmd_says_enabled)
           {
-            steer_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, dc_parser->output, cmd_turn_rate);
+            steer_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output, cmd_turn_rate);
             rx_it->second->setData(steer_encoder.data);
           }
         }
@@ -698,13 +699,13 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
 
             if (cmd_says_enabled)
             {
-              turn_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, dc_parser->output);
+              turn_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
               rx_it->second->setData(turn_encoder.data);
             }
           }
           else if (!cmd_says_enabled)
           {
-            turn_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, dc_parser->output);
+            turn_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
             rx_it->second->setData(turn_encoder.data);
           }
         }
@@ -719,13 +720,13 @@ void can_read(const can_msgs::Frame::ConstPtr &msg)
 
             if (cmd_says_enabled)
             {
-              wiper_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, dc_parser->output);
+              wiper_encoder.encode(dc_parser->enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
               rx_it->second->setData(wiper_encoder.data);
             }
           }
           else if (!cmd_says_enabled)
           {
-            wiper_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, dc_parser->output);
+            wiper_encoder.encode(cmd_says_enabled, cmd_says_ignore_overrides, cmd_says_clear_override, dc_parser->output);
             rx_it->second->setData(wiper_encoder.data);
           }
         }
@@ -922,7 +923,7 @@ int main(int argc, char *argv[])
     if (rx_it->first == TurnSignalCmdMsg::CAN_ID)
     {
       // Turn signals have non-0 initial value.
-      turn_encoder.encode(false, false, pacmod_msgs::SystemCmdInt::TURN_NONE);
+      turn_encoder.encode(false, false, false, pacmod_msgs::SystemCmdInt::TURN_NONE);
       rx_it->second->setData(turn_encoder.data);
     }
     else

--- a/pacmod3/src/pacmod3_ros_msg_handler.cpp
+++ b/pacmod3/src/pacmod3_ros_msg_handler.cpp
@@ -515,6 +515,7 @@ std::vector<uint8_t> Pacmod3RxRosMsgHandler::unpackAndEncode(const int64_t& can_
     HornCmdMsg encoder;
     encoder.encode(msg->enable,
                    msg->ignore_overrides,
+                   msg->clear_override,
                    msg->command);
     return encoder.data;
   }
@@ -523,6 +524,7 @@ std::vector<uint8_t> Pacmod3RxRosMsgHandler::unpackAndEncode(const int64_t& can_
     ParkingBrakeCmdMsg encoder;
     encoder.encode(msg->enable,
                    msg->ignore_overrides,
+                   msg->clear_override,
                    msg->command);
     return encoder.data;
   }
@@ -542,6 +544,7 @@ std::vector<uint8_t> Pacmod3RxRosMsgHandler::unpackAndEncode(const int64_t& can_
     AccelCmdMsg encoder;
     encoder.encode(msg->enable,
                    msg->ignore_overrides,
+                   msg->clear_override,
                    msg->command);
     return encoder.data;
 	}
@@ -550,6 +553,7 @@ std::vector<uint8_t> Pacmod3RxRosMsgHandler::unpackAndEncode(const int64_t& can_
     BrakeCmdMsg encoder;
     encoder.encode(msg->enable,
                    msg->ignore_overrides,
+                   msg->clear_override,
                    msg->command);
     return encoder.data;
 	}
@@ -569,6 +573,7 @@ std::vector<uint8_t> Pacmod3RxRosMsgHandler::unpackAndEncode(const int64_t& can_
     CruiseControlButtonsCmdMsg encoder;
     encoder.encode(msg->enable,
                    msg->ignore_overrides,
+                   msg->clear_override,
                    msg->command);
     return encoder.data;
   }
@@ -577,6 +582,7 @@ std::vector<uint8_t> Pacmod3RxRosMsgHandler::unpackAndEncode(const int64_t& can_
     DashControlsLeftCmdMsg encoder;
     encoder.encode(msg->enable,
                    msg->ignore_overrides,
+                   msg->clear_override,
                    msg->command);
     return encoder.data;
   }
@@ -585,6 +591,7 @@ std::vector<uint8_t> Pacmod3RxRosMsgHandler::unpackAndEncode(const int64_t& can_
     DashControlsRightCmdMsg encoder;
     encoder.encode(msg->enable,
                    msg->ignore_overrides,
+                   msg->clear_override,
                    msg->command);
     return encoder.data;
   }
@@ -593,6 +600,7 @@ std::vector<uint8_t> Pacmod3RxRosMsgHandler::unpackAndEncode(const int64_t& can_
     HeadlightCmdMsg encoder;
     encoder.encode(msg->enable,
                    msg->ignore_overrides,
+                   msg->clear_override,
                    msg->command);
     return encoder.data;
 	}
@@ -601,6 +609,7 @@ std::vector<uint8_t> Pacmod3RxRosMsgHandler::unpackAndEncode(const int64_t& can_
     MediaControlsCmdMsg encoder;
     encoder.encode(msg->enable,
                    msg->ignore_overrides,
+                   msg->clear_override,
                    msg->command);
     return encoder.data;
   }
@@ -609,6 +618,7 @@ std::vector<uint8_t> Pacmod3RxRosMsgHandler::unpackAndEncode(const int64_t& can_
     ShiftCmdMsg encoder;
     encoder.encode(msg->enable,
                    msg->ignore_overrides,
+                   msg->clear_override,
                    msg->command);
     return encoder.data;
 	}
@@ -617,6 +627,7 @@ std::vector<uint8_t> Pacmod3RxRosMsgHandler::unpackAndEncode(const int64_t& can_
     TurnSignalCmdMsg encoder;
     encoder.encode(msg->enable,
                    msg->ignore_overrides,
+                   msg->clear_override,
                    msg->command);
     return encoder.data;
 	}
@@ -625,6 +636,7 @@ std::vector<uint8_t> Pacmod3RxRosMsgHandler::unpackAndEncode(const int64_t& can_
     WiperCmdMsg encoder;
     encoder.encode(msg->enable,
                    msg->ignore_overrides,
+                   msg->clear_override,
                    msg->command);
     return encoder.data;
 	}
@@ -644,6 +656,7 @@ std::vector<uint8_t> Pacmod3RxRosMsgHandler::unpackAndEncode(const int64_t& can_
     SteerCmdMsg encoder;
     encoder.encode(msg->enable,
                    msg->ignore_overrides,
+                   msg->clear_override,
                    msg->command,
                    msg->rotation_rate);
     return encoder.data;


### PR DESCRIPTION
This requires approval of the maint/add_clear_override_flag branch
on astuff_sensor_messages - hence the change to .travis.rosinstall.
Will have to change this back to master once that branch is approved
and this is merged into master here.