### PR TITLE
CAN ID reorganization.

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,4 +1,3 @@
 - git:
     local-name: astuff_sensor_msgs
     uri: https://github.com/astuff/astuff_sensor_msgs
-    version: feature/add_more_aux_rpts

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: astuff_sensor_msgs
     uri: https://github.com/astuff/astuff_sensor_msgs
-    version: maint/add_clear_override_flag
+    version: feature/add_more_aux_rpts

--- a/pacmod3/include/pacmod3/pacmod3_common.h
+++ b/pacmod3/include/pacmod3/pacmod3_common.h
@@ -22,13 +22,13 @@
 #include <pacmod_msgs/BrakeAuxRpt.h>
 #include <pacmod_msgs/DateTimeRpt.h>
 #include <pacmod_msgs/DoorRpt.h>
-#include <pacmod_msgs/ExteriorLightsRpt.h>
 #include <pacmod_msgs/InteriorLightsRpt.h>
 #include <pacmod_msgs/LatLonHeadingRpt.h>
 #include <pacmod_msgs/MotorRpt1.h>
 #include <pacmod_msgs/MotorRpt2.h>
 #include <pacmod_msgs/MotorRpt3.h>
 #include <pacmod_msgs/OccupancyRpt.h>
+#include <pacmod_msgs/RearLightsRpt.h>
 #include <pacmod_msgs/ShiftAuxRpt.h>
 #include <pacmod_msgs/SteerAuxRpt.h>
 #include <pacmod_msgs/SteeringPIDRpt1.h>

--- a/pacmod3/include/pacmod3/pacmod3_core.h
+++ b/pacmod3/include/pacmod3/pacmod3_core.h
@@ -116,29 +116,11 @@ namespace PACMod3
       static const int64_t CAN_ID;
   };
 
-  class AccelAuxRptMsg :
-    public Pacmod3TxMsg
-  {
-    public:
-      static const int64_t CAN_ID;
-
-      void parse(uint8_t *in);
-  };
-
   class BrakeRptMsg :
     public SystemRptFloatMsg
   {
     public:
       static const int64_t CAN_ID;
-  };
-
-  class BrakeAuxRptMsg :
-    public Pacmod3TxMsg
-  {
-    public:
-      static const int64_t CAN_ID;
-
-      void parse(uint8_t *in);
   };
 
   class CruiseControlButtonsRptMsg :
@@ -157,6 +139,13 @@ namespace PACMod3
 
   class DashControlsRightRptMsg :
     public SystemRptIntMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+  };
+
+  class HazardLightRptMsg :
+    public SystemRptBoolMsg
   {
     public:
       static const int64_t CAN_ID;
@@ -197,39 +186,7 @@ namespace PACMod3
       static const int64_t CAN_ID;
   };
 
-  class ShiftAuxRptMsg :
-    public Pacmod3TxMsg
-  {
-    public:
-      static const int64_t CAN_ID;
-
-      void parse(uint8_t *in);
-  };
-
   class SteerRptMsg :
-    public SystemRptFloatMsg
-  {
-    public:
-      static const int64_t CAN_ID;
-  };
-
-  class SteerAuxRptMsg :
-    public Pacmod3TxMsg
-  {
-    public:
-      static const int64_t CAN_ID;
-
-      void parse(uint8_t *in);
-  };
-
-  class SteerRpt2Msg :
-    public SystemRptFloatMsg
-  {
-    public:
-      static const int64_t CAN_ID;
-  };
-
-  class SteerRpt3Msg :
     public SystemRptFloatMsg
   {
     public:
@@ -250,8 +207,95 @@ namespace PACMod3
       static const int64_t CAN_ID;
   };
 
+  // System Aux Reports
+  class AccelAuxRptMsg :
+    public Pacmod3TxMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+
+      void parse(uint8_t *in);
+  };
+
+  class BrakeAuxRptMsg :
+    public Pacmod3TxMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+
+      void parse(uint8_t *in);
+  };
+
+  class HeadlightAuxRptMsg :
+    public Pacmod3TxMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+
+      void parse(uint8_t *in);
+  };
+
+  class ParkingBrakeAuxRptMsg :
+    public Pacmod3TxMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+
+      void parse(uint8_t *in);
+  };
+
+  class ShiftAuxRptMsg :
+    public Pacmod3TxMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+
+      void parse(uint8_t *in);
+  };
+
+  class SteerAuxRptMsg :
+    public Pacmod3TxMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+
+      void parse(uint8_t *in);
+  };
+
+  class TurnAuxRptMsg :
+    public Pacmod3TxMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+
+      void parse(uint8_t *in);
+  };
+
+  class WiperAuxRptMsg :
+    public Pacmod3TxMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+
+      void parse(uint8_t *in);
+  };
+
   // Other Reports
-  class ExteriorLightsRptMsg :
+  class SteerRpt2Msg :
+    public SystemRptFloatMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+  };
+
+  class SteerRpt3Msg :
+    public SystemRptFloatMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+  };
+
+  class RearLightsRptMsg :
     public Pacmod3TxMsg
   {
     public:
@@ -500,6 +544,33 @@ namespace PACMod3
       void parse(uint8_t *in);
   };
 
+  class DetectedObjectRptMsg :
+    public Pacmod3TxMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+
+      void parse(uint8_t *in);
+  };
+
+  class VehicleControlsDetailRptMsg :
+    public Pacmod3TxMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+
+      void parse(uint8_t *in);
+  };
+
+  class VehicleDynamicsRptMsg :
+    public Pacmod3TxMsg
+  {
+    public:
+      static const int64_t CAN_ID;
+
+      void parse(uint8_t *in);
+  };
+
   // RX Messages
   class Pacmod3RxMsg
   {
@@ -540,6 +611,7 @@ namespace PACMod3
                   uint8_t cmd);
   };
 
+  // System Commands
   class AccelCmdMsg :
     public SystemCmdFloat
   {
@@ -570,6 +642,13 @@ namespace PACMod3
 
   class DashControlsRightCmdMsg :
     public SystemCmdInt
+  {
+    public:
+      static const int64_t CAN_ID;
+  };
+
+  class HazardLightCmdMsg :
+    public SystemCmdBool
   {
     public:
       static const int64_t CAN_ID;

--- a/pacmod3/include/pacmod3/pacmod3_ros_msg_handler.h
+++ b/pacmod3/include/pacmod3/pacmod3_ros_msg_handler.h
@@ -46,13 +46,13 @@ namespace PACMod3
       void fillBrakeAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::BrakeAuxRpt& new_msg, std::string frame_id);
       void fillDateTimeRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::DateTimeRpt& new_msg, std::string frame_id);
       void fillDoorRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::DoorRpt& new_msg, std::string frame_id);
-      void fillExteriorLightsRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::ExteriorLightsRpt& new_msg, std::string frame_id);
       void fillInteriorLightsRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::InteriorLightsRpt& new_msg, std::string frame_id);
       void fillLatLonHeadingRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::LatLonHeadingRpt& new_msg, std::string frame_id);
       void fillMotorRpt1(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::MotorRpt1& new_msg, std::string frame_id);
       void fillMotorRpt2(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::MotorRpt2& new_msg, std::string frame_id);
       void fillMotorRpt3(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::MotorRpt3& new_msg, std::string frame_id);
       void fillOccupancyRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::OccupancyRpt& new_msg, std::string frame_id);
+      void fillRearLightsRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::RearLightsRpt& new_msg, std::string frame_id);
       void fillShiftAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::ShiftAuxRpt& new_msg, std::string frame_id);
       void fillSteerAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::SteerAuxRpt& new_msg, std::string frame_id);
       void fillSteeringPIDRpt1(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::SteeringPIDRpt1& new_msg, std::string frame_id);

--- a/pacmod3/src/pacmod3_core.cpp
+++ b/pacmod3/src/pacmod3_core.cpp
@@ -9,60 +9,76 @@
 
 using namespace AS::Drivers::PACMod3;
 
-const int64_t AS::Drivers::PACMod3::TurnSignalCmdMsg::CAN_ID = 0x63;
-const int64_t AS::Drivers::PACMod3::TurnSignalRptMsg::CAN_ID = 0x64;
-const int64_t AS::Drivers::PACMod3::ShiftCmdMsg::CAN_ID = 0x65;
-const int64_t AS::Drivers::PACMod3::ShiftRptMsg::CAN_ID = 0x66;
-const int64_t AS::Drivers::PACMod3::AccelCmdMsg::CAN_ID = 0x67;
-const int64_t AS::Drivers::PACMod3::AccelRptMsg::CAN_ID = 0x68;
-const int64_t AS::Drivers::PACMod3::GlobalRptMsg::CAN_ID = 0x6A;
-const int64_t AS::Drivers::PACMod3::BrakeCmdMsg::CAN_ID = 0x6B;
-const int64_t AS::Drivers::PACMod3::BrakeRptMsg::CAN_ID = 0x6C;
-const int64_t AS::Drivers::PACMod3::SteerCmdMsg::CAN_ID = 0x6D;
-const int64_t AS::Drivers::PACMod3::SteerRptMsg::CAN_ID = 0x6E;
-const int64_t AS::Drivers::PACMod3::VehicleSpeedRptMsg::CAN_ID = 0x6F;
-const int64_t AS::Drivers::PACMod3::BrakeMotorRpt1Msg::CAN_ID = 0x70;
-const int64_t AS::Drivers::PACMod3::BrakeMotorRpt2Msg::CAN_ID = 0x71;
-const int64_t AS::Drivers::PACMod3::BrakeMotorRpt3Msg::CAN_ID = 0x72;
-const int64_t AS::Drivers::PACMod3::SteerMotorRpt1Msg::CAN_ID = 0x73;
-const int64_t AS::Drivers::PACMod3::SteerMotorRpt2Msg::CAN_ID = 0x74;
-const int64_t AS::Drivers::PACMod3::SteerMotorRpt3Msg::CAN_ID = 0x75;
-const int64_t AS::Drivers::PACMod3::HeadlightCmdMsg::CAN_ID = 0x76;
-const int64_t AS::Drivers::PACMod3::HeadlightRptMsg::CAN_ID = 0x77;
-const int64_t AS::Drivers::PACMod3::HornCmdMsg::CAN_ID = 0x78;
-const int64_t AS::Drivers::PACMod3::HornRptMsg::CAN_ID = 0x79;
-const int64_t AS::Drivers::PACMod3::WheelSpeedRptMsg::CAN_ID = 0x7A;
-const int64_t AS::Drivers::PACMod3::SteeringPIDRpt1Msg::CAN_ID = 0x7B;
-const int64_t AS::Drivers::PACMod3::SteeringPIDRpt2Msg::CAN_ID = 0x7C;
-const int64_t AS::Drivers::PACMod3::SteeringPIDRpt3Msg::CAN_ID = 0x7D;
-const int64_t AS::Drivers::PACMod3::SteerRpt2Msg::CAN_ID = 0x7E;
-const int64_t AS::Drivers::PACMod3::SteerRpt3Msg::CAN_ID = 0x7F;
-const int64_t AS::Drivers::PACMod3::ParkingBrakeRptMsg::CAN_ID = 0x80;
-const int64_t AS::Drivers::PACMod3::YawRateRptMsg::CAN_ID = 0x81;
-const int64_t AS::Drivers::PACMod3::LatLonHeadingRptMsg::CAN_ID = 0x82;
-const int64_t AS::Drivers::PACMod3::DateTimeRptMsg::CAN_ID = 0x83;
-const int64_t AS::Drivers::PACMod3::SteeringPIDRpt4Msg::CAN_ID = 0x84;
-const int64_t AS::Drivers::PACMod3::WiperCmdMsg::CAN_ID = 0x90;
-const int64_t AS::Drivers::PACMod3::WiperRptMsg::CAN_ID = 0x91;
-const int64_t AS::Drivers::PACMod3::ParkingBrakeCmdMsg::CAN_ID = 0x92;
-const int64_t AS::Drivers::PACMod3::CruiseControlButtonsCmdMsg::CAN_ID = 0x95;
-const int64_t AS::Drivers::PACMod3::CruiseControlButtonsRptMsg::CAN_ID = 0x96;
-const int64_t AS::Drivers::PACMod3::MediaControlsCmdMsg::CAN_ID = 0x97;
-const int64_t AS::Drivers::PACMod3::MediaControlsRptMsg::CAN_ID = 0x98;
-const int64_t AS::Drivers::PACMod3::DashControlsLeftCmdMsg::CAN_ID = 0x99;
-const int64_t AS::Drivers::PACMod3::DashControlsLeftRptMsg::CAN_ID = 0x9A;
-const int64_t AS::Drivers::PACMod3::DashControlsRightCmdMsg::CAN_ID = 0x9E;
-const int64_t AS::Drivers::PACMod3::DashControlsRightRptMsg::CAN_ID = 0x9F;
-const int64_t AS::Drivers::PACMod3::VinRptMsg::CAN_ID = 0xFF;
+const int64_t AS::Drivers::PACMod3::GlobalRptMsg::CAN_ID = 0x10;
 
-const int64_t AS::Drivers::PACMod3::AccelAuxRptMsg::CAN_ID = 0x100;
-const int64_t AS::Drivers::PACMod3::BrakeAuxRptMsg::CAN_ID = 0x101;
-const int64_t AS::Drivers::PACMod3::ShiftAuxRptMsg::CAN_ID = 0x102;
-const int64_t AS::Drivers::PACMod3::SteerAuxRptMsg::CAN_ID = 0x103;
-const int64_t AS::Drivers::PACMod3::OccupancyRptMsg::CAN_ID = 0x104;
-const int64_t AS::Drivers::PACMod3::InteriorLightsRptMsg::CAN_ID = 0x105;
-const int64_t AS::Drivers::PACMod3::ExteriorLightsRptMsg::CAN_ID = 0x106;
-const int64_t AS::Drivers::PACMod3::DoorRptMsg::CAN_ID = 0x107;
+// System Commands
+const int64_t AS::Drivers::PACMod3::AccelCmdMsg::CAN_ID = 0x100;
+const int64_t AS::Drivers::PACMod3::BrakeCmdMsg::CAN_ID = 0x104;
+const int64_t AS::Drivers::PACMod3::CruiseControlButtonsCmdMsg::CAN_ID = 0x108;
+const int64_t AS::Drivers::PACMod3::DashControlsLeftCmdMsg::CAN_ID = 0x10C;
+const int64_t AS::Drivers::PACMod3::DashControlsRightCmdMsg::CAN_ID = 0x110;
+const int64_t AS::Drivers::PACMod3::HazardLightCmdMsg::CAN_ID = 0x114;
+const int64_t AS::Drivers::PACMod3::HeadlightCmdMsg::CAN_ID = 0x118;
+const int64_t AS::Drivers::PACMod3::HornCmdMsg::CAN_ID = 0x11C;
+const int64_t AS::Drivers::PACMod3::MediaControlsCmdMsg::CAN_ID = 0x120;
+const int64_t AS::Drivers::PACMod3::ParkingBrakeCmdMsg::CAN_ID = 0x124;
+const int64_t AS::Drivers::PACMod3::ShiftCmdMsg::CAN_ID = 0x128;
+const int64_t AS::Drivers::PACMod3::SteerCmdMsg::CAN_ID = 0x12C;
+const int64_t AS::Drivers::PACMod3::TurnSignalCmdMsg::CAN_ID = 0x130;
+const int64_t AS::Drivers::PACMod3::WiperCmdMsg::CAN_ID = 0x134;
+
+// System Reports
+const int64_t AS::Drivers::PACMod3::AccelRptMsg::CAN_ID = 0x200;
+const int64_t AS::Drivers::PACMod3::BrakeRptMsg::CAN_ID = 0x204;
+const int64_t AS::Drivers::PACMod3::CruiseControlButtonsRptMsg::CAN_ID = 0x208;
+const int64_t AS::Drivers::PACMod3::DashControlsLeftRptMsg::CAN_ID = 0x20C;
+const int64_t AS::Drivers::PACMod3::DashControlsRightRptMsg::CAN_ID = 0x210;
+const int64_t AS::Drivers::PACMod3::HazardLightRptMsg::CAN_ID = 0x214;
+const int64_t AS::Drivers::PACMod3::HeadlightRptMsg::CAN_ID = 0x218;
+const int64_t AS::Drivers::PACMod3::HornRptMsg::CAN_ID = 0x21C;
+const int64_t AS::Drivers::PACMod3::MediaControlsRptMsg::CAN_ID = 0x220;
+const int64_t AS::Drivers::PACMod3::ParkingBrakeRptMsg::CAN_ID = 0x224;
+const int64_t AS::Drivers::PACMod3::ShiftRptMsg::CAN_ID = 0x228;
+const int64_t AS::Drivers::PACMod3::SteerRptMsg::CAN_ID = 0x22C;
+const int64_t AS::Drivers::PACMod3::TurnSignalRptMsg::CAN_ID = 0x230;
+const int64_t AS::Drivers::PACMod3::WiperRptMsg::CAN_ID = 0x234;
+
+// System Aux Reports
+const int64_t AS::Drivers::PACMod3::AccelAuxRptMsg::CAN_ID = 0x300;
+const int64_t AS::Drivers::PACMod3::BrakeAuxRptMsg::CAN_ID = 0x304;
+const int64_t AS::Drivers::PACMod3::HeadlightAuxRptMsg::CAN_ID = 0x318;
+const int64_t AS::Drivers::PACMod3::ParkingBrakeAuxRptMsg::CAN_ID = 0x324;
+const int64_t AS::Drivers::PACMod3::ShiftAuxRptMsg::CAN_ID = 0x328;
+const int64_t AS::Drivers::PACMod3::SteerAuxRptMsg::CAN_ID = 0x32C;
+const int64_t AS::Drivers::PACMod3::TurnAuxRptMsg::CAN_ID = 0x330;
+const int64_t AS::Drivers::PACMod3::WiperAuxRptMsg::CAN_ID = 0x334;
+
+// Misc. Reports
+const int64_t AS::Drivers::PACMod3::VehicleSpeedRptMsg::CAN_ID = 0x400;
+const int64_t AS::Drivers::PACMod3::BrakeMotorRpt1Msg::CAN_ID = 0x401;
+const int64_t AS::Drivers::PACMod3::BrakeMotorRpt2Msg::CAN_ID = 0x402;
+const int64_t AS::Drivers::PACMod3::BrakeMotorRpt3Msg::CAN_ID = 0x403;
+const int64_t AS::Drivers::PACMod3::SteerMotorRpt1Msg::CAN_ID = 0x404;
+const int64_t AS::Drivers::PACMod3::SteerMotorRpt2Msg::CAN_ID = 0x405;
+const int64_t AS::Drivers::PACMod3::SteerMotorRpt3Msg::CAN_ID = 0x406;
+const int64_t AS::Drivers::PACMod3::WheelSpeedRptMsg::CAN_ID = 0x407;
+const int64_t AS::Drivers::PACMod3::SteeringPIDRpt1Msg::CAN_ID = 0x408;
+const int64_t AS::Drivers::PACMod3::SteeringPIDRpt2Msg::CAN_ID = 0x409;
+const int64_t AS::Drivers::PACMod3::SteeringPIDRpt3Msg::CAN_ID = 0x40A;
+const int64_t AS::Drivers::PACMod3::SteerRpt2Msg::CAN_ID = 0x40B;
+const int64_t AS::Drivers::PACMod3::SteerRpt3Msg::CAN_ID = 0x40C;
+const int64_t AS::Drivers::PACMod3::YawRateRptMsg::CAN_ID = 0x40D;
+const int64_t AS::Drivers::PACMod3::LatLonHeadingRptMsg::CAN_ID = 0x40E;
+const int64_t AS::Drivers::PACMod3::DateTimeRptMsg::CAN_ID = 0x40F;
+const int64_t AS::Drivers::PACMod3::SteeringPIDRpt4Msg::CAN_ID = 0x410;
+const int64_t AS::Drivers::PACMod3::DetectedObjectRptMsg::CAN_ID = 0x411;
+const int64_t AS::Drivers::PACMod3::VehicleControlsDetailRptMsg::CAN_ID = 0x412;
+const int64_t AS::Drivers::PACMod3::VehicleDynamicsRptMsg::CAN_ID = 0x413;
+const int64_t AS::Drivers::PACMod3::VinRptMsg::CAN_ID = 0x414;
+const int64_t AS::Drivers::PACMod3::OccupancyRptMsg::CAN_ID = 0x415;
+const int64_t AS::Drivers::PACMod3::InteriorLightsRptMsg::CAN_ID = 0x416;
+const int64_t AS::Drivers::PACMod3::DoorRptMsg::CAN_ID = 0x417;
+const int64_t AS::Drivers::PACMod3::RearLightsRptMsg::CAN_ID = 0x418;
 
 std::shared_ptr<Pacmod3TxMsg> Pacmod3TxMsg::make_message(const int64_t& can_id)
 {
@@ -173,8 +189,8 @@ std::shared_ptr<Pacmod3TxMsg> Pacmod3TxMsg::make_message(const int64_t& can_id)
     case InteriorLightsRptMsg::CAN_ID:
       return std::shared_ptr<Pacmod3TxMsg>(new InteriorLightsRptMsg);
       break;
-    case ExteriorLightsRptMsg::CAN_ID:
-      return std::shared_ptr<Pacmod3TxMsg>(new ExteriorLightsRptMsg);
+    case RearLightsRptMsg::CAN_ID:
+      return std::shared_ptr<Pacmod3TxMsg>(new RearLightsRptMsg);
       break;
     default:
       return NULL;
@@ -300,7 +316,7 @@ void DoorRptMsg::parse(uint8_t *in)
 {
 }
 
-void ExteriorLightsRptMsg::parse(uint8_t *in)
+void RearLightsRptMsg::parse(uint8_t *in)
 {
 }
 

--- a/pacmod3/src/pacmod3_ros_msg_handler.cpp
+++ b/pacmod3/src/pacmod3_ros_msg_handler.cpp
@@ -113,12 +113,6 @@ void Pacmod3TxRosMsgHandler::fillAndPublish(const int64_t& can_id,
     fillDoorRpt(parser_class, new_msg, frame_id);
     pub.publish(new_msg);
   }
-  else if (can_id == ExteriorLightsRptMsg::CAN_ID)
-  {
-    pacmod_msgs::ExteriorLightsRpt new_msg;
-    fillExteriorLightsRpt(parser_class, new_msg, frame_id);
-    pub.publish(new_msg);
-  }
   else if (can_id == InteriorLightsRptMsg::CAN_ID)
   {
     pacmod_msgs::InteriorLightsRpt new_msg;
@@ -135,6 +129,12 @@ void Pacmod3TxRosMsgHandler::fillAndPublish(const int64_t& can_id,
   {
     pacmod_msgs::OccupancyRpt new_msg;
     fillOccupancyRpt(parser_class, new_msg, frame_id);
+    pub.publish(new_msg);
+  }
+  else if (can_id == RearLightsRptMsg::CAN_ID)
+  {
+    pacmod_msgs::RearLightsRpt new_msg;
+    fillRearLightsRpt(parser_class, new_msg, frame_id);
     pub.publish(new_msg);
   }
   else if (can_id == ShiftAuxRptMsg::CAN_ID)
@@ -316,14 +316,6 @@ void Pacmod3TxRosMsgHandler::fillDoorRpt(std::shared_ptr<Pacmod3TxMsg>& parser_c
   new_msg.header.stamp = ros::Time::now();
 }
 
-void Pacmod3TxRosMsgHandler::fillExteriorLightsRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::ExteriorLightsRpt& new_msg, std::string frame_id)
-{
-  auto dc_parser = std::dynamic_pointer_cast<ExteriorLightsRptMsg>(parser_class);
-
-  new_msg.header.frame_id = frame_id;
-  new_msg.header.stamp = ros::Time::now();
-}
-
 void Pacmod3TxRosMsgHandler::fillInteriorLightsRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::InteriorLightsRpt& new_msg, std::string frame_id)
 {
   auto dc_parser = std::dynamic_pointer_cast<InteriorLightsRptMsg>(parser_class);
@@ -343,14 +335,6 @@ void Pacmod3TxRosMsgHandler::fillLatLonHeadingRpt(std::shared_ptr<Pacmod3TxMsg>&
 	new_msg.longitude_minutes = dc_parser->longitude_minutes;
 	new_msg.longitude_seconds = dc_parser->longitude_seconds;
 	new_msg.heading = dc_parser->heading;
-
-  new_msg.header.frame_id = frame_id;
-  new_msg.header.stamp = ros::Time::now();
-}
-
-void Pacmod3TxRosMsgHandler::fillOccupancyRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::OccupancyRpt& new_msg, std::string frame_id)
-{
-  auto dc_parser = std::dynamic_pointer_cast<OccupancyRptMsg>(parser_class);
 
   new_msg.header.frame_id = frame_id;
   new_msg.header.stamp = ros::Time::now();
@@ -385,6 +369,22 @@ void Pacmod3TxRosMsgHandler::fillMotorRpt3(std::shared_ptr<Pacmod3TxMsg>& parser
 
 	new_msg.torque_output = dc_parser->torque_output;
 	new_msg.torque_input = dc_parser->torque_input;
+
+  new_msg.header.frame_id = frame_id;
+  new_msg.header.stamp = ros::Time::now();
+}
+
+void Pacmod3TxRosMsgHandler::fillOccupancyRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::OccupancyRpt& new_msg, std::string frame_id)
+{
+  auto dc_parser = std::dynamic_pointer_cast<OccupancyRptMsg>(parser_class);
+
+  new_msg.header.frame_id = frame_id;
+  new_msg.header.stamp = ros::Time::now();
+}
+
+void Pacmod3TxRosMsgHandler::fillRearLightsRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::RearLightsRpt& new_msg, std::string frame_id)
+{
+  auto dc_parser = std::dynamic_pointer_cast<RearLightsRptMsg>(parser_class);
 
   new_msg.header.frame_id = frame_id;
   new_msg.header.stamp = ros::Time::now();


### PR DESCRIPTION
After talking with the team, reorganizing the CAN IDs prior to
the use of a PACMod3 in production made sense. This includes
consideration for priority, grouping based on function, and leaving
space for future additions.