### PR TITLE
Maint/updates based on dbc changes

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,3 +1,4 @@
 - git:
     local-name: astuff_sensor_msgs
     uri: https://github.com/astuff/astuff_sensor_msgs
+    version: maint/update_pacmod3_msgs

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,4 +1,3 @@
 - git:
     local-name: astuff_sensor_msgs
     uri: https://github.com/astuff/astuff_sensor_msgs
-    version: maint/update_pacmod3_msgs

--- a/pacmod3/include/pacmod3/pacmod3_common.h
+++ b/pacmod3/include/pacmod3/pacmod3_common.h
@@ -40,8 +40,8 @@
 #include <pacmod_msgs/SystemRptBool.h>
 #include <pacmod_msgs/SystemRptFloat.h>
 #include <pacmod_msgs/SystemRptInt.h>
-#include <pacmod_msgs/VehicleControlsRpt.h>
 #include <pacmod_msgs/VehicleDynamicsRpt.h>
+#include <pacmod_msgs/VehicleSpecificRpt1.h>
 #include <pacmod_msgs/VehicleSpeedRpt.h>
 #include <pacmod_msgs/VinRpt.h>
 #include <pacmod_msgs/WheelSpeedRpt.h>

--- a/pacmod3/include/pacmod3/pacmod3_common.h
+++ b/pacmod3/include/pacmod3/pacmod3_common.h
@@ -23,6 +23,7 @@
 #include <pacmod_msgs/DateTimeRpt.h>
 #include <pacmod_msgs/DetectedObjectRpt.h>
 #include <pacmod_msgs/DoorRpt.h>
+#include <pacmod_msgs/HeadlightAuxRpt.h>
 #include <pacmod_msgs/InteriorLightsRpt.h>
 #include <pacmod_msgs/LatLonHeadingRpt.h>
 #include <pacmod_msgs/MotorRpt1.h>
@@ -40,11 +41,13 @@
 #include <pacmod_msgs/SystemRptBool.h>
 #include <pacmod_msgs/SystemRptFloat.h>
 #include <pacmod_msgs/SystemRptInt.h>
+#include <pacmod_msgs/TurnAuxRpt.h>
 #include <pacmod_msgs/VehicleDynamicsRpt.h>
 #include <pacmod_msgs/VehicleSpecificRpt1.h>
 #include <pacmod_msgs/VehicleSpeedRpt.h>
 #include <pacmod_msgs/VinRpt.h>
 #include <pacmod_msgs/WheelSpeedRpt.h>
+#include <pacmod_msgs/WiperAuxRpt.h>
 #include <pacmod_msgs/YawRateRpt.h>
 
 #endif

--- a/pacmod3/include/pacmod3/pacmod3_core.h
+++ b/pacmod3/include/pacmod3/pacmod3_core.h
@@ -282,20 +282,6 @@ namespace PACMod3
   };
 
   // Other Reports
-  class SteerRpt2Msg :
-    public SystemRptFloatMsg
-  {
-    public:
-      static const int64_t CAN_ID;
-  };
-
-  class SteerRpt3Msg :
-    public SystemRptFloatMsg
-  {
-    public:
-      static const int64_t CAN_ID;
-  };
-
   class RearLightsRptMsg :
     public Pacmod3TxMsg
   {
@@ -556,14 +542,12 @@ namespace PACMod3
       void parse(uint8_t *in);
   };
 
-  class VehicleControlsRptMsg :
+  class VehicleSpecificRpt1Msg :
     public Pacmod3TxMsg
   {
     public:
       static const int64_t CAN_ID;
 
-      double steering_rate;
-      double steering_torque;
       uint8_t shift_pos_1;
       uint8_t shift_pos_2;      
 

--- a/pacmod3/include/pacmod3/pacmod3_core.h
+++ b/pacmod3/include/pacmod3/pacmod3_core.h
@@ -215,6 +215,13 @@ namespace PACMod3
     public:
       static const int64_t CAN_ID;
 
+      float raw_pedal_pos;
+      float raw_pedal_force;
+      bool user_interaction;
+      bool raw_pedal_pos_is_valid;
+      bool raw_pedal_force_is_valid;
+      bool user_interaction_is_valid;
+
       void parse(uint8_t *in);
   };
 
@@ -223,6 +230,17 @@ namespace PACMod3
   {
     public:
       static const int64_t CAN_ID;
+
+      float raw_pedal_pos;
+      float raw_pedal_force;
+      float raw_brake_pressure;
+      bool user_interaction;
+      bool brake_on_off;
+      bool raw_pedal_pos_is_valid;
+      bool raw_pedal_force_is_valid;
+      bool raw_brake_pressure_is_valid;
+      bool user_interaction_is_valid;
+      bool brake_on_off_is_valid;
 
       void parse(uint8_t *in);
   };
@@ -233,14 +251,14 @@ namespace PACMod3
     public:
       static const int64_t CAN_ID;
 
-      void parse(uint8_t *in);
-  };
-
-  class ParkingBrakeAuxRptMsg :
-    public Pacmod3TxMsg
-  {
-    public:
-      static const int64_t CAN_ID;
+      bool headlights_on;
+      bool headlights_on_bright;
+      bool fog_lights_on;
+      uint8_t headlights_mode;
+      bool headlights_on_is_valid;
+      bool headlights_on_bright_is_valid;
+      bool fog_lights_on_is_valid;
+      bool headlights_mode_is_valid;
 
       void parse(uint8_t *in);
   };
@@ -251,6 +269,15 @@ namespace PACMod3
     public:
       static const int64_t CAN_ID;
 
+      bool between_gears;
+      bool stay_in_neutral_mode;
+      bool brake_interlock_active;
+      bool speed_interlock_active;
+      bool between_gears_is_valid;
+      bool stay_in_neutral_mode_is_valid;
+      bool brake_interlock_active_is_valid;
+      bool speed_interlock_active_is_valid;
+
       void parse(uint8_t *in);
   };
 
@@ -259,6 +286,15 @@ namespace PACMod3
   {
     public:
       static const int64_t CAN_ID;
+
+      float raw_position;
+      float raw_torque;
+      float rotation_rate;
+      bool user_interaction;
+      bool raw_position_is_valid;
+      bool raw_torque_is_valid;
+      bool rotation_rate_is_valid;
+      bool user_interaction_is_valid;
 
       void parse(uint8_t *in);
   };
@@ -269,6 +305,11 @@ namespace PACMod3
     public:
       static const int64_t CAN_ID;
 
+      bool driver_blinker_bulb_on;
+      bool passenger_blinker_bulb_on;
+      bool driver_blinker_bulb_on_is_valid;
+      bool passenger_blinker_bulb_on_is_valid;
+
       void parse(uint8_t *in);
   };
 
@@ -277,6 +318,19 @@ namespace PACMod3
   {
     public:
       static const int64_t CAN_ID;
+
+      bool front_wiping;
+      bool front_spraying;
+      bool rear_wiping;
+      bool rear_spraying;
+      bool spray_near_empty;
+      bool spray_empty;
+      bool front_wiping_is_valid;
+      bool front_spraying_is_valid;
+      bool rear_wiping_is_valid;
+      bool rear_spraying_is_valid;
+      bool spray_near_empty_is_valid;
+      bool spray_empty_is_valid;
 
       void parse(uint8_t *in);
   };

--- a/pacmod3/include/pacmod3/pacmod3_ros_msg_handler.h
+++ b/pacmod3/include/pacmod3/pacmod3_ros_msg_handler.h
@@ -60,7 +60,7 @@ namespace PACMod3
       void fillSteeringPIDRpt2(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::SteeringPIDRpt2& new_msg, std::string frame_id);
       void fillSteeringPIDRpt3(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::SteeringPIDRpt3& new_msg, std::string frame_id);
       void fillSteeringPIDRpt4(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::SteeringPIDRpt4& new_msg, std::string frame_id);
-      void fillVehicleControlsRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleControlsRpt& new_msg, std::string frame_id);
+      void fillVehicleSpecificRpt1(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleSpecificRpt1& new_msg, std::string frame_id);
       void fillVehicleDynamicsRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleDynamicsRpt& new_msg, std::string frame_id);
       void fillVehicleSpeedRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleSpeedRpt& new_msg, std::string frame_id);
       void fillVinRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VinRpt& new_msg, std::string frame_id);

--- a/pacmod3/include/pacmod3/pacmod3_ros_msg_handler.h
+++ b/pacmod3/include/pacmod3/pacmod3_ros_msg_handler.h
@@ -47,6 +47,7 @@ namespace PACMod3
       void fillDateTimeRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::DateTimeRpt& new_msg, std::string frame_id);
       void fillDetectedObjectRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::DetectedObjectRpt& new_msg, std::string frame_id);
       void fillDoorRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::DoorRpt& new_msg, std::string frame_id);
+      void fillHeadlightAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::HeadlightAuxRpt& new_msg, std::string frame_id);
       void fillInteriorLightsRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::InteriorLightsRpt& new_msg, std::string frame_id);
       void fillLatLonHeadingRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::LatLonHeadingRpt& new_msg, std::string frame_id);
       void fillMotorRpt1(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::MotorRpt1& new_msg, std::string frame_id);
@@ -60,11 +61,13 @@ namespace PACMod3
       void fillSteeringPIDRpt2(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::SteeringPIDRpt2& new_msg, std::string frame_id);
       void fillSteeringPIDRpt3(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::SteeringPIDRpt3& new_msg, std::string frame_id);
       void fillSteeringPIDRpt4(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::SteeringPIDRpt4& new_msg, std::string frame_id);
+      void fillTurnAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::TurnAuxRpt& new_msg, std::string frame_id);
       void fillVehicleSpecificRpt1(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleSpecificRpt1& new_msg, std::string frame_id);
       void fillVehicleDynamicsRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleDynamicsRpt& new_msg, std::string frame_id);
       void fillVehicleSpeedRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleSpeedRpt& new_msg, std::string frame_id);
       void fillVinRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VinRpt& new_msg, std::string frame_id);
       void fillWheelSpeedRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::WheelSpeedRpt& new_msg, std::string frame_id);
+      void fillWiperAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::WiperAuxRpt& new_msg, std::string frame_id);
       void fillYawRateRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::YawRateRpt& new_msg, std::string frame_id);
   };
 

--- a/pacmod3/src/pacmod3_core.cpp
+++ b/pacmod3/src/pacmod3_core.cpp
@@ -306,10 +306,40 @@ void SystemRptFloatMsg::parse(uint8_t *in)
 
 void AccelAuxRptMsg::parse(uint8_t *in)
 {
+  int16_t temp;
+
+  temp = ((int16_t)in[0] << 8) | in[1];
+  raw_pedal_pos = (float)temp / 1000.0;
+
+  temp = ((int16_t)in[2] << 8) | in[3];
+  raw_pedal_force = (float)temp / 1000.0;
+
+  user_interaction = (in[4] & 0x01) > 0;
+  raw_pedal_pos_is_valid = (in[5] & 0x01) > 0;
+  raw_pedal_force_is_valid = (in[5] & 0x02) > 0;
+  user_interaction_is_valid = (in[5] & 0x04) > 0;
 }
 
 void BrakeAuxRptMsg::parse(uint8_t *in)
 {
+  int16_t temp;
+
+  temp = ((int16_t)in[0] << 8) | in[1];
+  raw_pedal_pos = (float)temp / 1000.0;
+
+  temp = ((int16_t)in[2] << 8) | in[3];
+  raw_pedal_force = (float)temp / 1000.0;
+
+  temp = ((int16_t)in[4] << 8) | in[5];
+  raw_brake_pressure = (float)temp / 1000.0;
+
+  user_interaction = (in[6] & 0x01) > 0;
+  brake_on_off = (in[6] & 0x02) > 0;
+  raw_pedal_pos_is_valid = (in[7] & 0x01) > 0;
+  raw_pedal_force_is_valid = (in[7] & 0x02) > 0;
+  raw_brake_pressure_is_valid = (in[7] & 0x04) > 0;
+  user_interaction_is_valid = (in[7] & 0x08) > 0;
+  brake_on_off_is_valid = (in[7] & 0x10) > 0;
 }
 
 void DateTimeRptMsg::parse(uint8_t *in)
@@ -339,6 +369,14 @@ void DoorRptMsg::parse(uint8_t *in)
 
 void HeadlightAuxRptMsg::parse(uint8_t *in)
 {
+  headlights_on = (in[0] & 0x01) > 0;
+  headlights_on_bright = (in[0] & 0x02) > 0;
+  fog_lights_on = (in[0] & 0x04) > 0;
+  headlights_mode = in[1];
+  headlights_on_is_valid = (in[2] & 0x01) > 0;
+  headlights_on_bright_is_valid = (in[2] & 0x02) > 0;
+  fog_lights_on = (in[2] & 0x04) > 0;
+  headlights_mode_is_valid = (in[2] & 0x08) > 0;
 }
 
 void InteriorLightsRptMsg::parse(uint8_t *in)
@@ -403,10 +441,36 @@ void RearLightsRptMsg::parse(uint8_t *in)
 
 void ShiftAuxRptMsg::parse(uint8_t *in)
 {
+  between_gears = (in[0] & 0x01) > 0;
+  stay_in_neutral_mode = (in[0] & 0x02) > 0;
+  brake_interlock_active = (in[0] & 0x04) > 0;
+  speed_interlock_active = (in[0] & 0x08) > 0;
+  between_gears_is_valid = (in[1] & 0x01) > 0;
+  stay_in_neutral_mode_is_valid = (in[1] & 0x02) > 0;
+  brake_interlock_active_is_valid = (in[1] & 0x04) > 0;
+  speed_interlock_active_is_valid = (in[1] & 0x08) > 0;
 }
 
 void SteerAuxRptMsg::parse(uint8_t *in)
 {
+  int16_t temp;
+
+  temp = ((int16_t)in[0] << 8) | in[1];
+  raw_position = (float)temp / 1000.0;
+
+  temp = ((int16_t)in[2] << 8) | in[3];
+  raw_torque = (float)temp / 1000.0;
+
+  uint16_t temp2;
+
+  temp2 = ((uint16_t)in[4] << 8) | in[5];
+  rotation_rate = (float)temp2 / 1000.0;
+
+  user_interaction = (in[6] & 0x01) > 0;
+  raw_position_is_valid = (in[7] & 0x01) > 0;
+  raw_torque_is_valid = (in[7] & 0x02) > 0;
+  rotation_rate_is_valid = (in[7] & 0x04) > 0;
+  user_interaction_is_valid = (in[7] & 0x08) > 0;
 }
 
 void SteeringPIDRpt1Msg::parse(uint8_t *in)
@@ -473,6 +537,10 @@ void SteeringPIDRpt4Msg::parse(uint8_t *in)
 
 void TurnAuxRptMsg::parse(uint8_t *in)
 {
+  driver_blinker_bulb_on = (in[0] & 0x01) > 0;
+  passenger_blinker_bulb_on = (in[0] & 0x02) > 0;
+  driver_blinker_bulb_on_is_valid = (in[1] & 0x01) > 0;
+  passenger_blinker_bulb_on_is_valid = (in[1] & 0x02) > 0;
 }
 
 void VehicleSpecificRpt1Msg::parse(uint8_t *in)
@@ -616,6 +684,18 @@ void WheelSpeedRptMsg::parse(uint8_t *in)
 
 void WiperAuxRptMsg::parse(uint8_t *in)
 {
+  front_wiping = (in[0] & 0x01) > 0;
+  front_spraying = (in[0] & 0x02) > 0;
+  rear_wiping = (in[0] & 0x04) > 0;
+  rear_spraying = (in[0] & 0x08) > 0;
+  spray_near_empty = (in[0] & 0x10) > 0;
+  spray_empty = (in[0] & 0x20) > 0;
+  front_wiping_is_valid = (in[1] & 0x01) > 0;
+  front_spraying_is_valid = (in[1] & 0x02) > 0;
+  rear_wiping_is_valid = (in[1] & 0x04) > 0;
+  rear_spraying_is_valid = (in[1] & 0x08) > 0;
+  spray_near_empty_is_valid = (in[1] & 0x10) > 0;
+  spray_empty_is_valid = (in[1] & 0x20) > 0;
 }
 
 void YawRateRptMsg::parse(uint8_t *in)

--- a/pacmod3/src/pacmod3_core.cpp
+++ b/pacmod3/src/pacmod3_core.cpp
@@ -47,7 +47,6 @@ const int64_t AS::Drivers::PACMod3::WiperRptMsg::CAN_ID = 0x234;
 const int64_t AS::Drivers::PACMod3::AccelAuxRptMsg::CAN_ID = 0x300;
 const int64_t AS::Drivers::PACMod3::BrakeAuxRptMsg::CAN_ID = 0x304;
 const int64_t AS::Drivers::PACMod3::HeadlightAuxRptMsg::CAN_ID = 0x318;
-const int64_t AS::Drivers::PACMod3::ParkingBrakeAuxRptMsg::CAN_ID = 0x324;
 const int64_t AS::Drivers::PACMod3::ShiftAuxRptMsg::CAN_ID = 0x328;
 const int64_t AS::Drivers::PACMod3::SteerAuxRptMsg::CAN_ID = 0x32C;
 const int64_t AS::Drivers::PACMod3::TurnAuxRptMsg::CAN_ID = 0x330;
@@ -65,14 +64,12 @@ const int64_t AS::Drivers::PACMod3::WheelSpeedRptMsg::CAN_ID = 0x407;
 const int64_t AS::Drivers::PACMod3::SteeringPIDRpt1Msg::CAN_ID = 0x408;
 const int64_t AS::Drivers::PACMod3::SteeringPIDRpt2Msg::CAN_ID = 0x409;
 const int64_t AS::Drivers::PACMod3::SteeringPIDRpt3Msg::CAN_ID = 0x40A;
-const int64_t AS::Drivers::PACMod3::SteerRpt2Msg::CAN_ID = 0x40B;
-const int64_t AS::Drivers::PACMod3::SteerRpt3Msg::CAN_ID = 0x40C;
 const int64_t AS::Drivers::PACMod3::YawRateRptMsg::CAN_ID = 0x40D;
 const int64_t AS::Drivers::PACMod3::LatLonHeadingRptMsg::CAN_ID = 0x40E;
 const int64_t AS::Drivers::PACMod3::DateTimeRptMsg::CAN_ID = 0x40F;
 const int64_t AS::Drivers::PACMod3::SteeringPIDRpt4Msg::CAN_ID = 0x410;
 const int64_t AS::Drivers::PACMod3::DetectedObjectRptMsg::CAN_ID = 0x411;
-const int64_t AS::Drivers::PACMod3::VehicleControlsRptMsg::CAN_ID = 0x412;
+const int64_t AS::Drivers::PACMod3::VehicleSpecificRpt1Msg::CAN_ID = 0x412;
 const int64_t AS::Drivers::PACMod3::VehicleDynamicsRptMsg::CAN_ID = 0x413;
 const int64_t AS::Drivers::PACMod3::VinRptMsg::CAN_ID = 0x414;
 const int64_t AS::Drivers::PACMod3::OccupancyRptMsg::CAN_ID = 0x415;
@@ -150,17 +147,11 @@ std::shared_ptr<Pacmod3TxMsg> Pacmod3TxMsg::make_message(const int64_t& can_id)
     case SteerRptMsg::CAN_ID:
       return std::shared_ptr<Pacmod3TxMsg>(new SteerRptMsg);
       break;
-    case SteerRpt2Msg::CAN_ID:
-      return std::shared_ptr<Pacmod3TxMsg>(new SteerRpt2Msg);
-      break;
-    case SteerRpt3Msg::CAN_ID:
-      return std::shared_ptr<Pacmod3TxMsg>(new SteerRpt3Msg);
-      break;
     case TurnSignalRptMsg::CAN_ID:
       return std::shared_ptr<Pacmod3TxMsg>(new TurnSignalRptMsg);
       break;
-    case VehicleControlsRptMsg::CAN_ID:
-      return std::shared_ptr<Pacmod3TxMsg>(new VehicleControlsRptMsg);
+    case VehicleSpecificRpt1Msg::CAN_ID:
+      return std::shared_ptr<Pacmod3TxMsg>(new VehicleSpecificRpt1Msg);
       break;      
     case VehicleDynamicsRptMsg::CAN_ID:
       return std::shared_ptr<Pacmod3TxMsg>(new VehicleDynamicsRptMsg);
@@ -467,18 +458,10 @@ void SteeringPIDRpt4Msg::parse(uint8_t *in)
   angular_acceleration = (double)(temp / 1000.0);
 }
 
-void VehicleControlsRptMsg::parse(uint8_t *in)
+void VehicleSpecificRpt1Msg::parse(uint8_t *in)
 {
-  int16_t temp;
-  
-  temp = (((int16_t)in[0] << 8) | in[1]);
-  steering_rate = (double)(temp / 1000.0);
-  
-  temp = (((int16_t)in[2] << 8) | in[3]);
-  steering_torque = (double)(temp / 1000.0);
-               
-  shift_pos_1 = in[4];
-  shift_pos_2 = in[5];
+  shift_pos_1 = in[0];
+  shift_pos_2 = in[1];
 }
 
 void VehicleDynamicsRptMsg::parse(uint8_t *in)

--- a/pacmod3/src/pacmod3_core.cpp
+++ b/pacmod3/src/pacmod3_core.cpp
@@ -114,11 +114,20 @@ std::shared_ptr<Pacmod3TxMsg> Pacmod3TxMsg::make_message(const int64_t& can_id)
     case HornRptMsg::CAN_ID:
       return std::shared_ptr<Pacmod3TxMsg>(new HornRptMsg);
       break;
+    case InteriorLightsRptMsg::CAN_ID:
+      return std::shared_ptr<Pacmod3TxMsg>(new InteriorLightsRptMsg);
+      break;
     case LatLonHeadingRptMsg::CAN_ID:
       return std::shared_ptr<Pacmod3TxMsg>(new LatLonHeadingRptMsg);
       break;
+    case OccupancyRptMsg::CAN_ID:
+      return std::shared_ptr<Pacmod3TxMsg>(new OccupancyRptMsg);
+      break;
     case ParkingBrakeRptMsg::CAN_ID:
       return std::shared_ptr<Pacmod3TxMsg>(new ParkingBrakeRptMsg);
+      break;
+    case RearLightsRptMsg::CAN_ID:
+      return std::shared_ptr<Pacmod3TxMsg>(new RearLightsRptMsg);
       break;
     case ShiftRptMsg::CAN_ID:
       return std::shared_ptr<Pacmod3TxMsg>(new ShiftRptMsg);
@@ -177,20 +186,20 @@ std::shared_ptr<Pacmod3TxMsg> Pacmod3TxMsg::make_message(const int64_t& can_id)
     case BrakeAuxRptMsg::CAN_ID:
       return std::shared_ptr<Pacmod3TxMsg>(new BrakeAuxRptMsg);
       break;
+    case HeadlightAuxRptMsg::CAN_ID:
+      return std::shared_ptr<Pacmod3TxMsg>(new HeadlightAuxRptMsg);
+      break;
     case ShiftAuxRptMsg::CAN_ID:
       return std::shared_ptr<Pacmod3TxMsg>(new ShiftAuxRptMsg);
       break;
     case SteerAuxRptMsg::CAN_ID:
       return std::shared_ptr<Pacmod3TxMsg>(new SteerAuxRptMsg);
       break;
-    case OccupancyRptMsg::CAN_ID:
-      return std::shared_ptr<Pacmod3TxMsg>(new OccupancyRptMsg);
+    case TurnAuxRptMsg::CAN_ID:
+      return std::shared_ptr<Pacmod3TxMsg>(new TurnAuxRptMsg);
       break;
-    case InteriorLightsRptMsg::CAN_ID:
-      return std::shared_ptr<Pacmod3TxMsg>(new InteriorLightsRptMsg);
-      break;
-    case RearLightsRptMsg::CAN_ID:
-      return std::shared_ptr<Pacmod3TxMsg>(new RearLightsRptMsg);
+    case WiperAuxRptMsg::CAN_ID:
+      return std::shared_ptr<Pacmod3TxMsg>(new WiperAuxRptMsg);
       break;
     default:
       return NULL;
@@ -328,7 +337,7 @@ void DoorRptMsg::parse(uint8_t *in)
 {
 }
 
-void RearLightsRptMsg::parse(uint8_t *in)
+void HeadlightAuxRptMsg::parse(uint8_t *in)
 {
 }
 
@@ -385,6 +394,10 @@ void MotorRpt3Msg::parse(uint8_t *in)
 }
 
 void OccupancyRptMsg::parse(uint8_t *in)
+{
+}
+
+void RearLightsRptMsg::parse(uint8_t *in)
 {
 }
 
@@ -456,6 +469,10 @@ void SteeringPIDRpt4Msg::parse(uint8_t *in)
 
   temp = ((int16_t)in[2] << 8) | in[3];
   angular_acceleration = (double)(temp / 1000.0);
+}
+
+void TurnAuxRptMsg::parse(uint8_t *in)
+{
 }
 
 void VehicleSpecificRpt1Msg::parse(uint8_t *in)
@@ -595,6 +612,10 @@ void WheelSpeedRptMsg::parse(uint8_t *in)
 
   temp = ((int16_t)in[6] << 8) | in[7];
   rear_right_wheel_speed = (double)(temp / 100.0);
+}
+
+void WiperAuxRptMsg::parse(uint8_t *in)
+{
 }
 
 void YawRateRptMsg::parse(uint8_t *in)

--- a/pacmod3/src/pacmod3_node.cpp
+++ b/pacmod3/src/pacmod3_node.cpp
@@ -28,8 +28,6 @@ Pacmod3TxRosMsgHandler handler;
 ros::Publisher wiper_rpt_pub;
 ros::Publisher headlight_rpt_pub;
 ros::Publisher horn_rpt_pub;
-ros::Publisher steer_rpt_2_pub;
-ros::Publisher steer_rpt_3_pub;
 ros::Publisher wheel_speed_rpt_pub;
 ros::Publisher steering_pid_rpt_1_pub;
 ros::Publisher steering_pid_rpt_2_pub;
@@ -46,7 +44,7 @@ ros::Publisher brake_rpt_detail_1_pub;
 ros::Publisher brake_rpt_detail_2_pub;
 ros::Publisher brake_rpt_detail_3_pub;
 ros::Publisher detected_object_rpt_pub;
-ros::Publisher vehicle_controls_rpt_pub;
+ros::Publisher vehicle_specific_rpt_1_pub;
 ros::Publisher vehicle_dynamics_rpt_pub;
 
 //Vehicle-Specific Subscribers
@@ -376,8 +374,6 @@ int main(int argc, char *argv[])
     horn_rpt_pub = n.advertise<pacmod_msgs::SystemRptBool>("parsed_tx/horn_rpt", 20);
     lat_lon_heading_rpt_pub = n.advertise<pacmod_msgs::LatLonHeadingRpt>("parsed_tx/lat_lon_heading_rpt", 20);
     parking_brake_rpt_pub = n.advertise<pacmod_msgs::SystemRptBool>("parsed_tx/parking_brake_status_rpt", 20);
-    steer_rpt_2_pub = n.advertise<pacmod_msgs::SystemRptFloat>("parsed_tx/steer_rpt_2", 20);
-    steer_rpt_3_pub = n.advertise<pacmod_msgs::SystemRptFloat>("parsed_tx/steer_rpt_3", 20);
     steering_pid_rpt_1_pub = n.advertise<pacmod_msgs::SteeringPIDRpt1>("parsed_tx/steer_pid_rpt_1", 20);
     steering_pid_rpt_2_pub = n.advertise<pacmod_msgs::SteeringPIDRpt2>("parsed_tx/steer_pid_rpt_2", 20);
     steering_pid_rpt_3_pub = n.advertise<pacmod_msgs::SteeringPIDRpt3>("parsed_tx/steer_pid_rpt_3", 20);
@@ -390,8 +386,6 @@ int main(int argc, char *argv[])
     pub_tx_list.insert(std::make_pair(HornRptMsg::CAN_ID, horn_rpt_pub));
     pub_tx_list.insert(std::make_pair(LatLonHeadingRptMsg::CAN_ID, lat_lon_heading_rpt_pub));
     pub_tx_list.insert(std::make_pair(ParkingBrakeRptMsg::CAN_ID, parking_brake_rpt_pub));
-    pub_tx_list.insert(std::make_pair(SteerRpt2Msg::CAN_ID, steer_rpt_2_pub));
-    pub_tx_list.insert(std::make_pair(SteerRpt3Msg::CAN_ID, steer_rpt_3_pub));
     pub_tx_list.insert(std::make_pair(SteeringPIDRpt1Msg::CAN_ID, steering_pid_rpt_1_pub));
     pub_tx_list.insert(std::make_pair(SteeringPIDRpt2Msg::CAN_ID, steering_pid_rpt_2_pub));
     pub_tx_list.insert(std::make_pair(SteeringPIDRpt3Msg::CAN_ID, steering_pid_rpt_3_pub));

--- a/pacmod3/src/pacmod3_node.cpp
+++ b/pacmod3/src/pacmod3_node.cpp
@@ -26,7 +26,9 @@ Pacmod3TxRosMsgHandler handler;
 
 //Vehicle-Specific Publishers
 ros::Publisher wiper_rpt_pub;
+ros::Publisher wiper_aux_rpt_pub;
 ros::Publisher headlight_rpt_pub;
+ros::Publisher headlight_aux_rpt_pub;
 ros::Publisher horn_rpt_pub;
 ros::Publisher wheel_speed_rpt_pub;
 ros::Publisher steering_pid_rpt_1_pub;
@@ -64,6 +66,11 @@ ros::Publisher vehicle_speed_pub;
 ros::Publisher vehicle_speed_ms_pub;
 ros::Publisher enabled_pub;
 ros::Publisher can_rx_pub;
+ros::Publisher accel_aux_rpt_pub;
+ros::Publisher brake_aux_rpt_pub;
+ros::Publisher shift_aux_rpt_pub;
+ros::Publisher steer_aux_rpt_pub;
+ros::Publisher turn_aux_rpt_pub;
 
 std::unordered_map<long long, std::shared_ptr<LockedData>> rx_list;
 
@@ -298,6 +305,11 @@ int main(int argc, char *argv[])
   turn_rpt_pub = n.advertise<pacmod_msgs::SystemRptInt>("parsed_tx/turn_rpt", 20);
   vehicle_speed_pub = n.advertise<pacmod_msgs::VehicleSpeedRpt>("parsed_tx/vehicle_speed_rpt", 20);
   vin_rpt_pub = n.advertise<pacmod_msgs::VinRpt>("parsed_tx/vin_rpt", 5);
+  accel_aux_rpt_pub = n.advertise<pacmod_msgs::AccelAuxRpt>("parsed_tx/accel_aux_rpt", 20);
+  brake_aux_rpt_pub = n.advertise<pacmod_msgs::BrakeAuxRpt>("parsed_tx/brake_aux_rpt", 20);
+  shift_aux_rpt_pub = n.advertise<pacmod_msgs::ShiftAuxRpt>("parsed_tx/shift_aux_rpt", 20);
+  steer_aux_rpt_pub = n.advertise<pacmod_msgs::SteerAuxRpt>("parsed_tx/steer_aux_rpt", 20);
+  turn_aux_rpt_pub = n.advertise<pacmod_msgs::TurnAuxRpt>("parsed_tx/turn_aux_rpt", 20);
 
   enabled_pub = n.advertise<std_msgs::Bool>("as_tx/enabled", 20, true);
   vehicle_speed_ms_pub = n.advertise<std_msgs::Float64>("as_tx/vehicle_speed", 20);
@@ -313,6 +325,11 @@ int main(int argc, char *argv[])
   pub_tx_list.insert(std::make_pair(TurnSignalRptMsg::CAN_ID, turn_rpt_pub));
   pub_tx_list.insert(std::make_pair(VehicleSpeedRptMsg::CAN_ID, vehicle_speed_pub));
   pub_tx_list.insert(std::make_pair(VinRptMsg::CAN_ID, vin_rpt_pub));
+  pub_tx_list.insert(std::make_pair(AccelAuxRptMsg::CAN_ID, accel_aux_rpt_pub));
+  pub_tx_list.insert(std::make_pair(BrakeAuxRptMsg::CAN_ID, brake_aux_rpt_pub));
+  pub_tx_list.insert(std::make_pair(ShiftAuxRptMsg::CAN_ID, shift_aux_rpt_pub));
+  pub_tx_list.insert(std::make_pair(SteerAuxRptMsg::CAN_ID, steer_aux_rpt_pub));
+  pub_tx_list.insert(std::make_pair(TurnAuxRptMsg::CAN_ID, turn_aux_rpt_pub));
 
   // Subscribe to messages
   ros::Subscriber can_tx_sub = n.subscribe("can_tx", 20, can_read);
@@ -358,8 +375,10 @@ int main(int argc, char *argv[])
   if (veh_type == VehicleType::INTERNATIONAL_PROSTAR_122)
   {
     wiper_rpt_pub = n.advertise<pacmod_msgs::SystemRptInt>("parsed_tx/wiper_rpt", 20);
+    wiper_aux_rpt_pub = n.advertise<pacmod_msgs::WiperAuxRpt>("parsed_tx/wiper_aux_rpt", 20);
 
     pub_tx_list.insert(std::make_pair(WiperRptMsg::CAN_ID, wiper_rpt_pub));
+    pub_tx_list.insert(std::make_pair(WiperAuxRptMsg::CAN_ID, wiper_aux_rpt_pub));
 
     wiper_set_cmd_sub = std::shared_ptr<ros::Subscriber>(new ros::Subscriber(n.subscribe("as_rx/wiper_cmd", 20, callback_wiper_set_cmd)));
 
@@ -380,6 +399,7 @@ int main(int argc, char *argv[])
     steering_pid_rpt_4_pub = n.advertise<pacmod_msgs::SteeringPIDRpt4>("parsed_tx/steer_pid_rpt_4", 20);
     wheel_speed_rpt_pub = n.advertise<pacmod_msgs::WheelSpeedRpt>("parsed_tx/wheel_speed_rpt", 20);
     yaw_rate_rpt_pub = n.advertise<pacmod_msgs::YawRateRpt>("parsed_tx/yaw_rate_rpt", 20);
+    headlight_aux_rpt_pub = n.advertise<pacmod_msgs::HeadlightAuxRpt>("parsed_tx/headlight_aux_rpt", 20);
 
     pub_tx_list.insert(std::make_pair(DateTimeRptMsg::CAN_ID, date_time_rpt_pub));
     pub_tx_list.insert(std::make_pair(HeadlightRptMsg::CAN_ID, headlight_rpt_pub));
@@ -392,6 +412,7 @@ int main(int argc, char *argv[])
     pub_tx_list.insert(std::make_pair(SteeringPIDRpt4Msg::CAN_ID, steering_pid_rpt_4_pub));
     pub_tx_list.insert(std::make_pair(WheelSpeedRptMsg::CAN_ID, wheel_speed_rpt_pub));
     pub_tx_list.insert(std::make_pair(YawRateRptMsg::CAN_ID, yaw_rate_rpt_pub));
+    pub_tx_list.insert(std::make_pair(HeadlightAuxRptMsg::CAN_ID, headlight_aux_rpt_pub));
 
     headlight_set_cmd_sub = std::shared_ptr<ros::Subscriber>(new ros::Subscriber(n.subscribe("as_rx/headlight_cmd", 20, callback_headlight_set_cmd)));
     horn_set_cmd_sub = std::shared_ptr<ros::Subscriber>(new ros::Subscriber(n.subscribe("as_rx/horn_cmd", 20, callback_horn_set_cmd)));

--- a/pacmod3/src/pacmod3_ros_msg_handler.cpp
+++ b/pacmod3/src/pacmod3_ros_msg_handler.cpp
@@ -329,8 +329,8 @@ void Pacmod3TxRosMsgHandler::fillDetectedObjectRpt(std::shared_ptr<Pacmod3TxMsg>
 {
   auto dc_parser = std::dynamic_pointer_cast<DetectedObjectRptMsg>(parser_class);
 
-       new_msg.front_object_distance_low_res = dc_parser->front_object_distance_low_res;
-       new_msg.front_object_distance_high_res = dc_parser->front_object_distance_high_res;
+  new_msg.front_object_distance_low_res = dc_parser->front_object_distance_low_res;
+  new_msg.front_object_distance_high_res = dc_parser->front_object_distance_high_res;
 
   new_msg.header.frame_id = frame_id;
   new_msg.header.stamp = ros::Time::now();
@@ -344,20 +344,9 @@ void Pacmod3TxRosMsgHandler::fillDoorRpt(std::shared_ptr<Pacmod3TxMsg>& parser_c
   new_msg.header.stamp = ros::Time::now();
 }
 
-void Pacmod3TxRosMsgHandler::fillVehicleSpecificRpt1(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleSpecificRpt1& new_msg, std::string frame_id)
+void Pacmod3TxRosMsgHandler::fillHeadlightAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::HeadlightAuxRpt& new_msg, std::string frame_id)
 {
-  auto dc_parser = std::dynamic_pointer_cast<VehicleSpecificRpt1Msg>(parser_class);
-
-  new_msg.header.frame_id = frame_id;
-  new_msg.header.stamp = ros::Time::now();
-}
-
-void Pacmod3TxRosMsgHandler::fillVehicleDynamicsRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleDynamicsRpt& new_msg, std::string frame_id)
-{
-  auto dc_parser = std::dynamic_pointer_cast<VehicleDynamicsRptMsg>(parser_class);
-
-       new_msg.g_forces = dc_parser->g_forces;
-       new_msg.brake_torque = dc_parser->brake_torque;
+  auto dc_parser = std::dynamic_pointer_cast<HeadlightAuxRptMsg>(parser_class);
 
   new_msg.header.frame_id = frame_id;
   new_msg.header.stamp = ros::Time::now();
@@ -437,6 +426,14 @@ void Pacmod3TxRosMsgHandler::fillRearLightsRpt(std::shared_ptr<Pacmod3TxMsg>& pa
   new_msg.header.stamp = ros::Time::now();
 }
 
+void Pacmod3TxRosMsgHandler::fillTurnAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::TurnAuxRpt& new_msg, std::string frame_id)
+{
+  auto dc_parser = std::dynamic_pointer_cast<TurnAuxRptMsg>(parser_class);
+
+  new_msg.header.frame_id = frame_id;
+  new_msg.header.stamp = ros::Time::now();
+}
+
 void Pacmod3TxRosMsgHandler::fillShiftAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::ShiftAuxRpt& new_msg, std::string frame_id)
 {
   auto dc_parser = std::dynamic_pointer_cast<ShiftAuxRptMsg>(parser_class);
@@ -503,6 +500,25 @@ void Pacmod3TxRosMsgHandler::fillSteeringPIDRpt4(std::shared_ptr<Pacmod3TxMsg>& 
   new_msg.header.stamp = ros::Time::now();
 }
 
+void Pacmod3TxRosMsgHandler::fillVehicleDynamicsRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleDynamicsRpt& new_msg, std::string frame_id)
+{
+  auto dc_parser = std::dynamic_pointer_cast<VehicleDynamicsRptMsg>(parser_class);
+
+       new_msg.g_forces = dc_parser->g_forces;
+       new_msg.brake_torque = dc_parser->brake_torque;
+
+  new_msg.header.frame_id = frame_id;
+  new_msg.header.stamp = ros::Time::now();
+}
+
+void Pacmod3TxRosMsgHandler::fillVehicleSpecificRpt1(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleSpecificRpt1& new_msg, std::string frame_id)
+{
+  auto dc_parser = std::dynamic_pointer_cast<VehicleSpecificRpt1Msg>(parser_class);
+
+  new_msg.header.frame_id = frame_id;
+  new_msg.header.stamp = ros::Time::now();
+}
+
 void Pacmod3TxRosMsgHandler::fillVehicleSpeedRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleSpeedRpt& new_msg, std::string frame_id)
 {
   auto dc_parser = std::dynamic_pointer_cast<VehicleSpeedRptMsg>(parser_class);
@@ -538,6 +554,14 @@ void Pacmod3TxRosMsgHandler::fillWheelSpeedRpt(std::shared_ptr<Pacmod3TxMsg>& pa
 	new_msg.front_right_wheel_speed = dc_parser->front_right_wheel_speed;
 	new_msg.rear_left_wheel_speed = dc_parser->rear_left_wheel_speed;
 	new_msg.rear_right_wheel_speed = dc_parser->rear_right_wheel_speed;
+
+  new_msg.header.frame_id = frame_id;
+  new_msg.header.stamp = ros::Time::now();
+}
+
+void Pacmod3TxRosMsgHandler::fillWiperAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::WiperAuxRpt& new_msg, std::string frame_id)
+{
+  auto dc_parser = std::dynamic_pointer_cast<WiperAuxRptMsg>(parser_class);
 
   new_msg.header.frame_id = frame_id;
   new_msg.header.stamp = ros::Time::now();

--- a/pacmod3/src/pacmod3_ros_msg_handler.cpp
+++ b/pacmod3/src/pacmod3_ros_msg_handler.cpp
@@ -111,6 +111,12 @@ void Pacmod3TxRosMsgHandler::fillAndPublish(const int64_t& can_id,
     fillDoorRpt(parser_class, new_msg, frame_id);
     pub.publish(new_msg);
   }
+  else if (can_id == HeadlightAuxRptMsg::CAN_ID)
+  {
+    pacmod_msgs::HeadlightAuxRpt new_msg;
+    fillHeadlightAuxRpt(parser_class, new_msg, frame_id);
+    pub.publish(new_msg);
+  }
   else if (can_id == InteriorLightsRptMsg::CAN_ID)
   {
     pacmod_msgs::InteriorLightsRpt new_msg;
@@ -171,6 +177,12 @@ void Pacmod3TxRosMsgHandler::fillAndPublish(const int64_t& can_id,
     fillSteeringPIDRpt4(parser_class, new_msg, frame_id);
     pub.publish(new_msg);
   }
+  else if (can_id == TurnAuxRptMsg::CAN_ID)
+  {
+    pacmod_msgs::TurnAuxRpt new_msg;
+    fillTurnAuxRpt(parser_class, new_msg, frame_id);
+    pub.publish(new_msg);
+  }
   else if (can_id == YawRateRptMsg::CAN_ID)
   {
     pacmod_msgs::YawRateRpt new_msg;
@@ -193,6 +205,12 @@ void Pacmod3TxRosMsgHandler::fillAndPublish(const int64_t& can_id,
   {
     pacmod_msgs::WheelSpeedRpt new_msg;
     fillWheelSpeedRpt(parser_class, new_msg, frame_id);
+    pub.publish(new_msg);
+  }
+  else if (can_id == WiperAuxRptMsg::CAN_ID)
+  {
+    pacmod_msgs::WiperAuxRpt new_msg;
+    fillWiperAuxRpt(parser_class, new_msg, frame_id);
     pub.publish(new_msg);
   }
   else if (can_id == DetectedObjectRptMsg::CAN_ID)
@@ -298,6 +316,13 @@ void Pacmod3TxRosMsgHandler::fillAccelAuxRpt(std::shared_ptr<Pacmod3TxMsg>& pars
 {
   auto dc_parser = std::dynamic_pointer_cast<AccelAuxRptMsg>(parser_class);
 
+  new_msg.raw_pedal_pos = dc_parser->raw_pedal_pos;
+  new_msg.raw_pedal_force = dc_parser->raw_pedal_force;
+  new_msg.user_interaction = dc_parser->user_interaction;
+  new_msg.raw_pedal_pos_is_valid = dc_parser->raw_pedal_pos_is_valid;
+  new_msg.raw_pedal_force_is_valid = dc_parser->raw_pedal_force_is_valid;
+  new_msg.user_interaction_is_valid = dc_parser->user_interaction_is_valid;
+
   new_msg.header.frame_id = frame_id;
   new_msg.header.stamp = ros::Time::now();
 }
@@ -305,6 +330,16 @@ void Pacmod3TxRosMsgHandler::fillAccelAuxRpt(std::shared_ptr<Pacmod3TxMsg>& pars
 void Pacmod3TxRosMsgHandler::fillBrakeAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::BrakeAuxRpt& new_msg, std::string frame_id)
 {
   auto dc_parser = std::dynamic_pointer_cast<BrakeAuxRptMsg>(parser_class);
+
+  new_msg.raw_pedal_pos = dc_parser->raw_pedal_pos;
+  new_msg.raw_pedal_force = dc_parser->raw_pedal_force;
+  new_msg.raw_brake_pressure = dc_parser->raw_brake_pressure;
+  new_msg.user_interaction = dc_parser->user_interaction;
+  new_msg.brake_on_off = dc_parser->brake_on_off;
+  new_msg.raw_pedal_pos_is_valid = dc_parser->raw_pedal_pos_is_valid;
+  new_msg.raw_pedal_force_is_valid = dc_parser->raw_pedal_force_is_valid;
+  new_msg.user_interaction_is_valid = dc_parser->user_interaction_is_valid;
+  new_msg.brake_on_off_is_valid = dc_parser->brake_on_off_is_valid;
 
   new_msg.header.frame_id = frame_id;
   new_msg.header.stamp = ros::Time::now();
@@ -347,6 +382,15 @@ void Pacmod3TxRosMsgHandler::fillDoorRpt(std::shared_ptr<Pacmod3TxMsg>& parser_c
 void Pacmod3TxRosMsgHandler::fillHeadlightAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::HeadlightAuxRpt& new_msg, std::string frame_id)
 {
   auto dc_parser = std::dynamic_pointer_cast<HeadlightAuxRptMsg>(parser_class);
+
+  new_msg.headlights_on = dc_parser->headlights_on;
+  new_msg.headlights_on_bright = dc_parser->headlights_on_bright;
+  new_msg.fog_lights_on = dc_parser->fog_lights_on;
+  new_msg.headlights_mode = dc_parser->headlights_mode;
+  new_msg.headlights_on_is_valid = dc_parser->headlights_on_is_valid;
+  new_msg.headlights_on_bright_is_valid = dc_parser->headlights_on_bright_is_valid;
+  new_msg.fog_lights_on_is_valid = dc_parser->fog_lights_on_is_valid;
+  new_msg.headlights_mode_is_valid = dc_parser->headlights_mode_is_valid;
 
   new_msg.header.frame_id = frame_id;
   new_msg.header.stamp = ros::Time::now();
@@ -426,17 +470,18 @@ void Pacmod3TxRosMsgHandler::fillRearLightsRpt(std::shared_ptr<Pacmod3TxMsg>& pa
   new_msg.header.stamp = ros::Time::now();
 }
 
-void Pacmod3TxRosMsgHandler::fillTurnAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::TurnAuxRpt& new_msg, std::string frame_id)
-{
-  auto dc_parser = std::dynamic_pointer_cast<TurnAuxRptMsg>(parser_class);
-
-  new_msg.header.frame_id = frame_id;
-  new_msg.header.stamp = ros::Time::now();
-}
-
 void Pacmod3TxRosMsgHandler::fillShiftAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::ShiftAuxRpt& new_msg, std::string frame_id)
 {
   auto dc_parser = std::dynamic_pointer_cast<ShiftAuxRptMsg>(parser_class);
+
+  new_msg.between_gears = dc_parser->between_gears;
+  new_msg.stay_in_neutral_mode = dc_parser->stay_in_neutral_mode;
+  new_msg.brake_interlock_active = dc_parser->brake_interlock_active;
+  new_msg.speed_interlock_active = dc_parser->speed_interlock_active;
+  new_msg.between_gears_is_valid = dc_parser->between_gears_is_valid;
+  new_msg.stay_in_neutral_mode_is_valid = dc_parser->stay_in_neutral_mode_is_valid;
+  new_msg.brake_interlock_active_is_valid = dc_parser->brake_interlock_active_is_valid;
+  new_msg.speed_interlock_active_is_valid = dc_parser->speed_interlock_active_is_valid;
 
   new_msg.header.frame_id = frame_id;
   new_msg.header.stamp = ros::Time::now();
@@ -445,6 +490,15 @@ void Pacmod3TxRosMsgHandler::fillShiftAuxRpt(std::shared_ptr<Pacmod3TxMsg>& pars
 void Pacmod3TxRosMsgHandler::fillSteerAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::SteerAuxRpt& new_msg, std::string frame_id)
 {
   auto dc_parser = std::dynamic_pointer_cast<SteerAuxRptMsg>(parser_class);
+
+  new_msg.raw_position = dc_parser->raw_position;
+  new_msg.raw_torque = dc_parser->raw_torque;
+  new_msg.rotation_rate = dc_parser->rotation_rate;
+  new_msg.user_interaction = dc_parser->user_interaction;
+  new_msg.raw_position_is_valid = dc_parser->raw_position_is_valid;
+  new_msg.raw_torque_is_valid = dc_parser->raw_torque_is_valid;
+  new_msg.rotation_rate_is_valid = dc_parser->rotation_rate_is_valid;
+  new_msg.user_interaction_is_valid = dc_parser->user_interaction_is_valid;
 
   new_msg.header.frame_id = frame_id;
   new_msg.header.stamp = ros::Time::now();
@@ -495,6 +549,19 @@ void Pacmod3TxRosMsgHandler::fillSteeringPIDRpt4(std::shared_ptr<Pacmod3TxMsg>& 
 
 	new_msg.angular_velocity = dc_parser->angular_velocity;
 	new_msg.angular_acceleration = dc_parser->angular_acceleration;
+
+  new_msg.header.frame_id = frame_id;
+  new_msg.header.stamp = ros::Time::now();
+}
+
+void Pacmod3TxRosMsgHandler::fillTurnAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::TurnAuxRpt& new_msg, std::string frame_id)
+{
+  auto dc_parser = std::dynamic_pointer_cast<TurnAuxRptMsg>(parser_class);
+
+  new_msg.driver_blinker_bulb_on = dc_parser->driver_blinker_bulb_on;
+  new_msg.passenger_blinker_bulb_on = dc_parser->passenger_blinker_bulb_on;
+  new_msg.driver_blinker_bulb_on_is_valid = dc_parser->driver_blinker_bulb_on_is_valid;
+  new_msg.passenger_blinker_bulb_on_is_valid = dc_parser->passenger_blinker_bulb_on_is_valid;
 
   new_msg.header.frame_id = frame_id;
   new_msg.header.stamp = ros::Time::now();
@@ -562,6 +629,19 @@ void Pacmod3TxRosMsgHandler::fillWheelSpeedRpt(std::shared_ptr<Pacmod3TxMsg>& pa
 void Pacmod3TxRosMsgHandler::fillWiperAuxRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::WiperAuxRpt& new_msg, std::string frame_id)
 {
   auto dc_parser = std::dynamic_pointer_cast<WiperAuxRptMsg>(parser_class);
+
+  new_msg.front_wiping = dc_parser->front_wiping;
+  new_msg.front_spraying = dc_parser->front_spraying;
+  new_msg.rear_wiping = dc_parser->rear_wiping;
+  new_msg.rear_spraying = dc_parser->rear_spraying;
+  new_msg.spray_near_empty = dc_parser->spray_near_empty;
+  new_msg.spray_empty = dc_parser->spray_empty;
+  new_msg.front_wiping_is_valid = dc_parser->front_wiping_is_valid;
+  new_msg.front_spraying_is_valid = dc_parser->front_spraying_is_valid;
+  new_msg.rear_wiping_is_valid = dc_parser->rear_wiping_is_valid;
+  new_msg.rear_spraying_is_valid = dc_parser->rear_spraying_is_valid;
+  new_msg.spray_near_empty_is_valid = dc_parser->spray_near_empty_is_valid;
+  new_msg.spray_empty_is_valid = dc_parser->spray_empty_is_valid;
 
   new_msg.header.frame_id = frame_id;
   new_msg.header.stamp = ros::Time::now();

--- a/pacmod3/src/pacmod3_ros_msg_handler.cpp
+++ b/pacmod3/src/pacmod3_ros_msg_handler.cpp
@@ -54,9 +54,7 @@ void Pacmod3TxRosMsgHandler::fillAndPublish(const int64_t& can_id,
   }
   else if (can_id == AccelRptMsg::CAN_ID ||
            can_id == BrakeRptMsg::CAN_ID ||
-           can_id == SteerRptMsg::CAN_ID ||
-           can_id == SteerRpt2Msg::CAN_ID ||
-           can_id == SteerRpt3Msg::CAN_ID)
+           can_id == SteerRptMsg::CAN_ID)
   {
     pacmod_msgs::SystemRptFloat new_msg;
     fillSystemRptFloat(parser_class, new_msg, frame_id);
@@ -203,10 +201,10 @@ void Pacmod3TxRosMsgHandler::fillAndPublish(const int64_t& can_id,
     fillDetectedObjectRpt(parser_class, new_msg, frame_id);
     pub.publish(new_msg);
   }      
-  else if (can_id == VehicleControlsRptMsg::CAN_ID)
+  else if (can_id == VehicleSpecificRpt1Msg::CAN_ID)
   {
-    pacmod_msgs::VehicleControlsRpt new_msg;
-    fillVehicleControlsRpt(parser_class, new_msg, frame_id);
+    pacmod_msgs::VehicleSpecificRpt1 new_msg;
+    fillVehicleSpecificRpt1(parser_class, new_msg, frame_id);
     pub.publish(new_msg);
   }  
   else if (can_id == VehicleDynamicsRptMsg::CAN_ID)
@@ -346,14 +344,9 @@ void Pacmod3TxRosMsgHandler::fillDoorRpt(std::shared_ptr<Pacmod3TxMsg>& parser_c
   new_msg.header.stamp = ros::Time::now();
 }
 
-void Pacmod3TxRosMsgHandler::fillVehicleControlsRpt(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleControlsRpt& new_msg, std::string frame_id)
+void Pacmod3TxRosMsgHandler::fillVehicleSpecificRpt1(std::shared_ptr<Pacmod3TxMsg>& parser_class, pacmod_msgs::VehicleSpecificRpt1& new_msg, std::string frame_id)
 {
-  auto dc_parser = std::dynamic_pointer_cast<VehicleControlsRptMsg>(parser_class);
-
-       new_msg.steering_rate = dc_parser->steering_rate;
-       new_msg.steering_torque = dc_parser->steering_torque;
-       new_msg.shift_pos_1 = dc_parser->shift_pos_1;
-       new_msg.shift_pos_2 = dc_parser->shift_pos_2;
+  auto dc_parser = std::dynamic_pointer_cast<VehicleSpecificRpt1Msg>(parser_class);
 
   new_msg.header.frame_id = frame_id;
   new_msg.header.stamp = ros::Time::now();


### PR DESCRIPTION
These changes compile but are essentially untested because we don't have firmware that produces any of these messages. However, this should guarantee that they're safe for the current vehicles since they shouldn't encounter any of these CAN IDs yet.